### PR TITLE
[go-metro] Updated git to pull from gopkg.in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,21 @@ RUN yum -y install \
 RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 RUN \curl -sSL https://get.rvm.io | bash -s stable
 RUN /bin/bash -l -c "rvm requirements"
-RUN /bin/bash -l -c "rvm install 2.2.2"
-
-RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
+RUN /bin/bash -l -c "rvm install 2.1.5"
 
 # Install go (required by to build gohai)
 RUN curl -o /tmp/go1.3.3.linux-amd64.tar.gz https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf /tmp/go1.3.3.linux-amd64.tar.gz && \
     echo "PATH=$PATH:/usr/local/go/bin" | tee /etc/profile.d/go.sh
 
+# Upgrade openssl
+RUN curl -L -o /tmp/rpmforge-release-0.5.3-1.el5.rf.x86_64.rpm http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el5.rf.x86_64.rpm && \
+    rpm --import http://apt.sw.be/RPM-GPG-KEY.dag.txt && \
+    yum -y localinstall /tmp/rpmforge-release-0.5.3-1.el5.rf.x86_64.rpm
+
+RUN sed -i '/rpmforge-extras/,/^enabled\|^\[/s/^enabled.*/enabled = 1/' /etc/yum.repos.d/rpmforge.repo
+
 RUN yum -y install \
-    git \
     install \
     perl-ExtUtils-MakeMaker \
     fakeroot
@@ -46,12 +50,48 @@ RUN cd /tmp && tar -xzf /tmp/tar123.tar.gz
 RUN rm -f /bin/tar /bin/gtar
 RUN cd /tmp/tar-1.23 && FORCE_UNSAFE_CONFIGURE=1 ./configure --prefix=/ && make && make install && ln -sf /bin/tar /bin/gtar
 
+RUN curl -o /tmp/openssl-1.0.1r.tar.gz http://artfiles.org/openssl.org/source/openssl-1.0.1r.tar.gz
+RUN cd /tmp && tar -xzf /tmp/openssl-1.0.1r.tar.gz
+RUN cd /tmp/openssl-1.0.1r && ./Configure linux-x86_64 no-shared --openssldir=/opt/openssl -fPIC && make && make install
+
+# now build git
+# dependencies
+RUN yum -y install \
+    expat-devel \
+    gettext-devel \
+    perl-devel \
+    zlib-devel
+
+RUN curl -o /tmp/curl-7.46.0.tar.gz http://curl.askapache.com/download/curl-7.46.0.tar.gz
+RUN cd /tmp && tar -xzf /tmp/curl-7.46.0.tar.gz
+RUN cd /tmp/curl-7.46.0 && LIBS="-ldl" ./configure --enable-static --prefix=/opt/curl --with-ssl=/opt/openssl && make all && make install
+
+RUN curl -o /tmp/git-2.7.0.tar.gz https://www.kernel.org/pub/software/scm/git/git-2.7.0.tar.gz
+RUN cd /tmp && tar -xzf /tmp/git-2.7.0.tar.gz
+RUN cd /tmp/git-2.7.0 && make configure && ./configure --with-ssl --prefix=/usr \
+       OPENSSLDIR=/opt/openssl \
+       CURLDIR=/opt/curl \
+       CPPFLAGS="-I/opt/curl/include" \
+       LDFLAGS="-L/opt/curl/lib" && make all && make install
+
+RUN mkdir -p /etc/ld.so.conf.d/
+RUN echo "/opt/curl/lib" > /etc/ld.so.conf.d/optcurl.conf
+RUN ldconfig
+
+RUN /bin/bash -l -c "CPPFLAGS='-I/usr/local/rvm/gems/ruby-2.2.2/include' rvm install 2.2.2 --with-openssl-dir=/opt/openssl"
+RUN /bin/bash -l -c "rvm --default use 2.2.2"
+RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
+
 RUN git config --global user.email "package@datadoghq.com"
 RUN git config --global user.name "Centos Omnibus Package"
 RUN git clone https://github.com/DataDog/dd-agent-omnibus.git
 # TODO: remove the checkout line after the merge to master
 RUN cd dd-agent-omnibus && \
     /bin/bash -l -c "bundle install --binstubs"
+
+# bootstap our CERTS
+RUN /opt/curl/bin/curl -kfsSL curl.haxx.se/ca/cacert.pem \
+                       -o $(/bin/bash -l -c "ruby -ropenssl -e 'puts OpenSSL::X509::DEFAULT_CERT_FILE'")
 
 VOLUME ["/dd-agent-omnibus/pkg"]
 


### PR DESCRIPTION
# Why #
As we had learnt with the `deb` build, `dd-tcp-rtt` has dependencies hosted in gopkg.in. Unfortunately this causes issues when cloning the repos due to the older versions of `openssl` and `curl` in CentOS5. Although upgrading to CentOS6 would solve the problem in a less cumbersome way, this is currently not possible due to BC.

# How #
To solve this we build **openssl** and **curl** from source (and in that order has curl depend on openssl as well), and install them to `/opt`, we then build **git** against these two local libs (while using the system-wide libraries for everything else). After that, we add the local curl shared-library to the `LD_LIBRARY_PATH` so it may be found by the git binary. I tried to link statically to no avail. :disappointed: 