### PR TITLE
Use a stable URL for openssl's source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN cd /tmp && tar -xzf /tmp/tar123.tar.gz && \
     ln -sf /bin/tar /bin/gtar && \
     cd - && rm -rf /tmp/tar123.tar.gz
 
-RUN curl -o /tmp/openssl-1.0.1r.tar.gz http://artfiles.org/openssl.org/source/openssl-1.0.1r.tar.gz && \
+RUN curl -o /tmp/openssl-1.0.1r.tar.gz http://artfiles.org/openssl.org/source/old/1.0.1/openssl-1.0.1r.tar.gz && \
     cd /tmp && tar -xzf /tmp/openssl-1.0.1r.tar.gz && \
     cd /tmp/openssl-1.0.1r && ./Configure linux-x86_64 no-shared --openssldir=/opt/openssl -fPIC && make && make install && \
     cd - && rm -rf /tmp/openssl-1.0.1r && rm /tmp/openssl-1.0.1r.tar.gz


### PR DESCRIPTION
Only the latest openssl version is available in `/source/`, so use the more stable `/source/old/1.0.1/` path

cc @truthbk 