### PR TITLE
Setting the dd-agent-omnibus branch on the docker side

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,8 @@ RUN git clone https://github.com/DataDog/integrations-core.git
 
 RUN echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = http://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=http://yum.datadoghq.com/DATADOG_RPM_KEY.public' > /etc/yum.repos.d/datadog.repo
 
+ADD checkout_omnibus_branch.sh /
+
 VOLUME ["/dd-agent-omnibus/pkg"]
 
-ENTRYPOINT /bin/bash -l /dd-agent-omnibus/omnibus_build.sh
+ENTRYPOINT /bin/bash -l /checkout_omnibus_branch.sh

--- a/checkout_omnibus_branch.sh
+++ b/checkout_omnibus_branch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+cd /dd-agent-omnibus
+
+# Allow to use a different dd-agent-omnibus branch
+git fetch --all
+git checkout ${OMNIBUS_BRANCH:-"master"}
+git reset --hard origin/${OMNIBUS_BRANCH:-"master"}
+
+# running the entrypoint from dd-agent-omnibus
+cd /
+bash -l /dd-agent-omnibus/omnibus_build.sh


### PR DESCRIPTION
This allows us to update the omnibus_build.sh script in dd-agent-omnibus
without rebuilding the container.