### PR TITLE
update go to 1.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,10 @@ RUN /bin/bash -l -c "CPPFLAGS='-I/usr/local/rvm/gems/ruby-2.2.2/include' rvm ins
                        -o $(/bin/bash -l -c "ruby -ropenssl -e 'puts OpenSSL::X509::DEFAULT_CERT_FILE'") && \
     /bin/bash -l -c "gem install bundler --no-ri --no-rdoc" && rm -rf /usr/local/rvm/src/ruby-2.2.2
 
+# Update go to 1.10.3
+RUN curl -o /tmp/go1.10.3.linux-amd64.tar.gz https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go1.10.3.linux-amd64.tar.gz
+
 RUN git config --global user.email "package@datadoghq.com" && \
     git config --global user.name "Centos Omnibus Package" && \
     git clone https://github.com/DataDog/dd-agent-omnibus.git

--- a/history/bump-go-1-10-3/Dockerfile
+++ b/history/bump-go-1-10-3/Dockerfile
@@ -1,0 +1,6 @@
+FROM datadog/docker-dd-agent-build-rpm-x64:latest
+MAINTAINER Remi Hakim @remh
+
+# Update go to 1.10.3
+RUN curl -o /tmp/go1.10.3.linux-amd64.tar.gz https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go1.10.3.linux-amd64.tar.gz

--- a/history/bump-go-1-10-3/Dockerfile
+++ b/history/bump-go-1-10-3/Dockerfile
@@ -1,4 +1,4 @@
-FROM datadog/docker-dd-agent-build-rpm-x64:latest
+FROM datadog/docker-dd-agent-build-rpm-x64:20180108
 MAINTAINER Remi Hakim @remh
 
 # Update go to 1.10.3

--- a/tmp/Dockerfile
+++ b/tmp/Dockerfile
@@ -1,0 +1,6 @@
+FROM datadog/docker-dd-agent-build-rpm-x64:latest
+MAINTAINER Remi Hakim @remh
+
+# Update go to 1.10.3
+RUN curl -o /tmp/go1.10.3.linux-amd64.tar.gz https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go1.10.3.linux-amd64.tar.gz

--- a/tmp/Dockerfile
+++ b/tmp/Dockerfile
@@ -1,6 +1,0 @@
-FROM datadog/docker-dd-agent-build-rpm-x64:latest
-MAINTAINER Remi Hakim @remh
-
-# Update go to 1.10.3
-RUN curl -o /tmp/go1.10.3.linux-amd64.tar.gz https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf /tmp/go1.10.3.linux-amd64.tar.gz


### PR DESCRIPTION
`tmp/Dockerfile` will be removed before merging. 
To know why we need this: https://github.com/DataDog/docker-dd-agent-build-rpm-x64#important-note

`go-metro` can not be compiled using a recent go version on centos5. It will be pre-compiled on centos6 and pushed to a bucket. Omnibus will download it during the build process. 