### PR TITLE
[curl/openssl] fixes broken TLS v1.2 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           keys:
             - omnibus-rpm-cache-{{ checksum "~/cache_key.txt" }}
       - run: echo -e $RPM_GPG_KEY > /home/circleci/keys/RPM-SIGNING-KEY.private
-      - run: docker run -e RELEASE_VERSION=$RELEASE_VERSION -e RPM_SIGNING_PASSPHRASE=$RPM_SIGNING_PASSPHRASE -e OMNIBUS_BRANCH=$OMNIBUS_BRANCH -v /home/circleci/keys:/keys -v /home/circleci/pkg:/dd-agent-omnibus/pkg -v /home/circleci/cache:/var/cache/omnibus datadog/docker-dd-agent-build-rpm-x64
+      - run: docker run -e RELEASE_VERSION=$RELEASE_VERSION -e RPM_SIGNING_PASSPHRASE=$RPM_SIGNING_PASSPHRASE -e OMNIBUS_BRANCH=$OMNIBUS_BRANCH -v /home/circleci/keys:/keys -v /home/circleci/pkg:/dd-agent-omnibus/pkg -v /home/circleci/cache:/var/cache/omnibus jfullaondo/docker-dd-agent-build-rpm-x64:latest
       - save_cache:
           key: omnibus-rpm-cache-{{ checksum "~/cache_key.txt" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           keys:
             - omnibus-rpm-cache-{{ checksum "~/cache_key.txt" }}
       - run: echo -e $RPM_GPG_KEY > /home/circleci/keys/RPM-SIGNING-KEY.private
-      - run: docker run -e RELEASE_VERSION=$RELEASE_VERSION -e RPM_SIGNING_PASSPHRASE=$RPM_SIGNING_PASSPHRASE -e OMNIBUS_BRANCH=$OMNIBUS_BRANCH -v /home/circleci/keys:/keys -v /home/circleci/pkg:/dd-agent-omnibus/pkg -v /home/circleci/cache:/var/cache/omnibus jfullaondo/docker-dd-agent-build-rpm-x64:latest
+      - run: docker run -e RELEASE_VERSION=$RELEASE_VERSION -e RPM_SIGNING_PASSPHRASE=$RPM_SIGNING_PASSPHRASE -e OMNIBUS_BRANCH=$OMNIBUS_BRANCH -v /home/circleci/keys:/keys -v /home/circleci/pkg:/dd-agent-omnibus/pkg -v /home/circleci/cache:/var/cache/omnibus jfullaondo/docker-dd-agent-build-rpm-x64:final
       - save_cache:
           key: omnibus-rpm-cache-{{ checksum "~/cache_key.txt" }}
           paths:

--- a/CentOS-Base.repo
+++ b/CentOS-Base.repo
@@ -1,0 +1,34 @@
+# CentOS-Base.repo
+#
+# The mirror system uses the connecting IP address of the client and the
+# update status of each mirror to pick mirrors that are updated to and
+# geographically close to the client. You should use this for CentOS updates
+# unless you are manually picking other mirrors.
+#
+# If the mirrorlist= does not work for you, as a fall back you can try the
+# remarked out baseurl= line instead.
+#
+#
+[base]
+name=CentOS-$releasever - Base
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os
+baseurl=http://vault.centos.org/5.11/os/x86_64/
+#baseurl=http://mirror.centos.org/centos/$releasever/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+#released updates
+[updates]
+name=CentOS-$releasever - Updates
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates
+baseurl=http://vault.centos.org/5.11/updates/x86_64/
+#baseurl=http://mirror.centos.org/centos/$releasever/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+#additional packages that may be useful
+[extras]
+name=CentOS-$releasever - Extras
+mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras
+baseurl=http://vault.centos.org/5.11/extras/x86_64/
+#baseurl=http://mirror.centos.org/centos/$releasever/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM centos:5
 MAINTAINER Remi Hakim @remh
 
+COPY ./CentOS-Base.repo /etc/yum.repos.d/CentOS-Base.repo
+COPY ./libselinux.repo /etc/yum.repos.d/libselinux.repo
+
+RUN yum -y update
+
 RUN yum -y install \
     rpm-build \
     xz \
@@ -19,10 +24,54 @@ RUN yum -y install \
     freetype-devel \
     libart_lgpl-devel \
     gcc \
-    groff
+    groff \
+    wget \
+    automake \
+    libffi-devel \
+    libyaml-devel
+
+# RUN cd tmp && \
+#     wget https://www.openssl.org/source/openssl-1.0.2a.tar.gz && \
+#     tar -zxvf openssl-*.tar.gz && \
+#     cd openssl-*/ && \
+#     ./config -fpic shared && make && make install && \
+#     echo "/usr/local/ssl/lib" >> /etc/ld.so.conf && \
+#     ldconfig
+
+RUN yum -y install \
+    make \
+    automake \
+    autoconf \
+    install \
+    perl-ExtUtils-MakeMaker \
+    fakeroot
+
+RUN curl -o /tmp/openssl-1.0.2u.tar.gz http://artfiles.org/openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz && \
+    cd /tmp && tar -xzf /tmp/openssl-1.0.2u.tar.gz && \
+    cd /tmp/openssl-1.0.2u && ./Configure linux-x86_64 no-shared --openssldir=/opt/openssl -fPIC && make && make install && \
+    echo "/usr/local/ssl/lib" >> /etc/ld.so.conf && ldconfig && \
+    cd - && rm -rf /tmp/openssl-1.0.2u && rm /tmp/openssl-1.0.2u.tar.gz
+
+COPY ./curl-7.46.0.tar.gz /tmp/curl-7.46.0.tar.gz
+
+RUN cd /tmp && tar -xzf /tmp/curl-7.46.0.tar.gz && \
+    cd /tmp/curl-7.46.0 && LIBS="-ldl" ./configure --enable-static --prefix=/opt/curl --with-ssl=/opt/openssl && make all && make install && \
+    cd - && rm -rf /tmp/curl-7.46.0 && rm -f /tmp/curl-7.46.0.tar.gz
+
+# # Upgrade openssl
+# RUN rpm -Uvh  http://repoforge.eecs.wsu.edu/redhat/el5/en/x86_64/rpmforge/RPMS/$(curl -s http://repoforge.eecs.wsu.edu/redhat/el5/en/x86_64/rpmforge/RPMS/ | grep rpmforge-release | grep x86_64 | grep el5 | sort | tail -n1 | sed 's%.*>\(rpmforge\-release\-.*.rpm\)<.*%\1%')
+# RUN sed -i 's/apt\.sw\.be/repoforge.eecs.wsu.edu/g' /etc/yum.repos.d/rpmforge.repo && \
+#     sed -i '/rpmforge-extras/,/^enabled\|^\[/s/^enabled.*/enabled = 1/' /etc/yum.repos.d/rpmforge.repo
+#
+# RUN yum -y install \
+#     install \
+#     perl-ExtUtils-MakeMaker \
+#     fakeroot
+
+ENV PATH="/opt/curl/bin:${PATH}"
 
 # Set up an RVM with Ruby 2.2.2
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN curl -sSL https://get.rvm.io | bash -s stable && \
     /bin/bash -l -c "rvm requirements" && \
     /bin/bash -l -c "rvm install 2.1.5" && \
@@ -33,28 +82,13 @@ RUN curl -o /tmp/go1.3.3.linux-amd64.tar.gz https://storage.googleapis.com/golan
     tar -C /usr/local -xzf /tmp/go1.3.3.linux-amd64.tar.gz && \
     echo "PATH=$PATH:/usr/local/go/bin" | tee /etc/profile.d/go.sh
 
-# Upgrade openssl
-RUN rpm -Uvh  http://repoforge.eecs.wsu.edu/redhat/el5/en/x86_64/rpmforge/RPMS/$(curl -s http://repoforge.eecs.wsu.edu/redhat/el5/en/x86_64/rpmforge/RPMS/ | grep rpmforge-release | grep x86_64 | grep el5 | sort | tail -n1 | sed 's%.*>\(rpmforge\-release\-.*.rpm\)<.*%\1%')
-RUN sed -i 's/apt\.sw\.be/repoforge.eecs.wsu.edu/g' /etc/yum.repos.d/rpmforge.repo && \
-    sed -i '/rpmforge-extras/,/^enabled\|^\[/s/^enabled.*/enabled = 1/' /etc/yum.repos.d/rpmforge.repo
-
-RUN yum -y install \
-    install \
-    perl-ExtUtils-MakeMaker \
-    fakeroot
-
 # Install tar >> 1.23 so that Omnibus can use the -J option
-RUN \curl -o /tmp/tar123.tar.gz http://ftp.gnu.org/gnu/tar/tar-1.23.tar.gz
+RUN curl -o /tmp/tar123.tar.gz -L http://ftp.gnu.org/gnu/tar/tar-1.23.tar.gz
 RUN cd /tmp && tar -xzf /tmp/tar123.tar.gz && \
     rm -f /bin/tar /bin/gtar && \
     cd /tmp/tar-1.23 && FORCE_UNSAFE_CONFIGURE=1 ./configure --prefix=/ && make && make install && \
     ln -sf /bin/tar /bin/gtar && \
     cd - && rm -rf /tmp/tar123.tar.gz
-
-RUN curl -o /tmp/openssl-1.0.1r.tar.gz http://artfiles.org/openssl.org/source/old/1.0.1/openssl-1.0.1r.tar.gz && \
-    cd /tmp && tar -xzf /tmp/openssl-1.0.1r.tar.gz && \
-    cd /tmp/openssl-1.0.1r && ./Configure linux-x86_64 no-shared --openssldir=/opt/openssl -fPIC && make && make install && \
-    cd - && rm -rf /tmp/openssl-1.0.1r && rm /tmp/openssl-1.0.1r.tar.gz
 
 # now build git
 # dependencies
@@ -64,12 +98,7 @@ RUN yum -y install \
     perl-devel \
     zlib-devel
 
-RUN curl -o /tmp/curl-7.46.0.tar.gz http://curl.askapache.com/download/curl-7.46.0.tar.gz && \
-    cd /tmp && tar -xzf /tmp/curl-7.46.0.tar.gz && \
-    cd /tmp/curl-7.46.0 && LIBS="-ldl" ./configure --enable-static --prefix=/opt/curl --with-ssl=/opt/openssl && make all && make install && \
-    cd - && rm -rf /tmp/curl-7.46.0 && rm -f /tmp/curl-7.46.0.tar.gz
-
-RUN /opt/curl/bin/curl -o /tmp/git-2.7.0.tar.gz https://www.kernel.org/pub/software/scm/git/git-2.7.0.tar.gz && \
+RUN /opt/curl/bin/curl -o /tmp/git-2.7.0.tar.gz -L https://www.kernel.org/pub/software/scm/git/git-2.7.0.tar.gz && \
     cd /tmp && tar -xzf /tmp/git-2.7.0.tar.gz && \
     cd /tmp/git-2.7.0 && make configure && ./configure --with-ssl --prefix=/usr \
        OPENSSLDIR=/opt/openssl \
@@ -85,7 +114,7 @@ RUN /bin/bash -l -c "CPPFLAGS='-I/usr/local/rvm/gems/ruby-2.2.2/include' rvm ins
     /bin/bash -l -c "rvm --default use 2.2.2" && \
     /opt/curl/bin/curl -kfsSL curl.haxx.se/ca/cacert.pem \
                        -o $(/bin/bash -l -c "ruby -ropenssl -e 'puts OpenSSL::X509::DEFAULT_CERT_FILE'") && \
-    /bin/bash -l -c "gem install bundler --no-ri --no-rdoc" && rm -rf /usr/local/rvm/src/ruby-2.2.2
+    /bin/bash -l -c "gem install bundler -v 1.17.3" && rm -rf /usr/local/rvm/src/ruby-2.2.2
 
 # Update go to 1.10.3
 RUN curl -o /tmp/go1.10.3.linux-amd64.tar.gz https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz && \
@@ -99,7 +128,7 @@ RUN cd dd-agent-omnibus && \
     /bin/bash -l -c "OMNIBUS_RUBY_BRANCH='datadog-5.5.0' bundle install --binstubs"
 
 RUN git clone https://github.com/DataDog/integrations-extras.git
-RUN git clone https://github.com/DataDog/integrations-core.git
+RUN git clone --progress https://github.com/DataDog/integrations-core.git
 
 RUN echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = http://yum.datadoghq.com/rpm/x86_64/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=http://yum.datadoghq.com/DATADOG_RPM_KEY.public' > /etc/yum.repos.d/datadog.repo
 

--- a/libselinux.repo
+++ b/libselinux.repo
@@ -1,0 +1,9 @@
+# Since official repositories are gone, use vault.centos.org instead.
+
+[libselinux]
+name=CentOS-5 - libselinux
+baseurl=http://vault.centos.org/5.11/centosplus/$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
+includepkgs=libselinux*


### PR DESCRIPTION
This PR fixes the image such that we can continue using TLS v1.2 endpoints with curl (inability to pull from virtually everywhere was breaking our builds).